### PR TITLE
Small refactor to gain access to all key components at top level

### DIFF
--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -38,8 +38,9 @@ pub struct NES {
     pub ppu: Rc<RefCell<ppu::PPU>>,
     pub apu: Rc<RefCell<apu::APU>>,
     pub mapper: Rc<RefCell<memory::Mapper>>,
-    pub cpu_memory: Rc<RefCell<memory::CPUMemory>>,
-    pub ppu_memory: Rc<RefCell<memory::PPUMemory>>,
+    pub ram: Rc<RefCell<memory::RAM>>,
+    pub sram: Rc<RefCell<memory::RAM>>,
+    pub vram: Rc<RefCell<memory::RAM>>,
     nmi_pin: bool,
 }
 
@@ -52,15 +53,20 @@ impl NES {
         // Load ROM into memory.
         let mapper = NES::load(rom);
 
+        // Create RAM modules.
+        let ram = Rc::new(RefCell::new(memory::RAM::new()));
+        let sram = Rc::new(RefCell::new(memory::RAM::new()));
+        let vram = Rc::new(RefCell::new(memory::RAM::new()));
+
         // Create graphics output module and PPU.
-        let ppu_memory = Rc::new(RefCell::new(memory::PPUMemory::new(
+        let ppu_memory = memory::PPUMemory::new(
             Box::new(memory::ChrMapper::new(mapper.clone())),
             Box::new(mapper.clone()),
-            Box::new(memory::RAM::new()),
-        )));
+            Box::new(vram.clone()),
+        );
 
         let ppu = Rc::new(RefCell::new(ppu::PPU::new(
-                    Box::new(ppu_memory.clone()),
+                    ppu_memory,
                     Box::new(video))));
 
         // Create APU.
@@ -94,15 +100,15 @@ impl NES {
             Box::new(joy2.clone()),
         )));
 
-        let cpu_memory = Rc::new(RefCell::new(memory::CPUMemory::new(
-            Box::new(memory::RAM::new()),
+        let cpu_memory = memory::CPUMemory::new(
+            Box::new(ram.clone()),
             Box::new(ppu.clone()),
             Box::new(io_registers.clone()),
-            Box::new(memory::RAM::new()),
+            Box::new(sram.clone()),
             Box::new(memory::PrgMapper::new(mapper.clone()))
-        )));
+        );
 
-        let cpu = Rc::new(RefCell::new(cpu::new(Box::new(cpu_memory.clone()))));
+        let cpu = Rc::new(RefCell::new(cpu::new(Box::new(cpu_memory))));
         cpu.borrow_mut().disable_bcd();
         cpu.borrow_mut().startup_sequence();
 
@@ -125,8 +131,9 @@ impl NES {
             ppu,
             apu,
             mapper,
-            cpu_memory,
-            ppu_memory,
+            ram,
+            sram,
+            vram,
             nmi_pin: false,
         }
     }

--- a/src/emulator/ppu/mod.rs
+++ b/src/emulator/ppu/mod.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 use emulator::clock;
 use emulator::components::bitfield::BitField;
 use emulator::components::latch;
-use emulator::memory::{PPUMemory, Reader};
+use emulator::memory::{ReadWriter, Reader};
 use emulator::util;
 
 // Colours represented as a single byte:
@@ -96,7 +96,7 @@ pub struct PPU {
     // $3000-$3EFF = mirrors of $2000-$2EFF
     // $3F00-$3F1F = palette RAM indexes
     // $3F20-$3FFF = mirrors of $3F00-$3F1F
-    memory: PPUMemory,
+    memory: Box<dyn ReadWriter>,
 
     // -- Background State --
 
@@ -199,7 +199,7 @@ impl clock::Ticker for PPU {
 }
 
 impl PPU {
-    pub fn new(memory: PPUMemory, output: Box<VideoOut>) -> PPU {
+    pub fn new(memory: Box<dyn ReadWriter>, output: Box<VideoOut>) -> PPU {
         PPU {
             output: output,
             ppuctrl: BitField::new(),

--- a/src/emulator/ppu/mod.rs
+++ b/src/emulator/ppu/mod.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 use emulator::clock;
 use emulator::components::bitfield::BitField;
 use emulator::components::latch;
-use emulator::memory::{ReadWriter, Reader};
+use emulator::memory::{PPUMemory, Reader};
 use emulator::util;
 
 // Colours represented as a single byte:
@@ -96,7 +96,7 @@ pub struct PPU {
     // $3000-$3EFF = mirrors of $2000-$2EFF
     // $3F00-$3F1F = palette RAM indexes
     // $3F20-$3FFF = mirrors of $3F00-$3F1F
-    memory: Box<dyn ReadWriter>,
+    memory: PPUMemory,
 
     // -- Background State --
 
@@ -199,7 +199,7 @@ impl clock::Ticker for PPU {
 }
 
 impl PPU {
-    pub fn new(memory: Box<dyn ReadWriter>, output: Box<VideoOut>) -> PPU {
+    pub fn new(memory: PPUMemory, output: Box<VideoOut>) -> PPU {
         PPU {
             output: output,
             ppuctrl: BitField::new(),


### PR DESCRIPTION
Wrap the various RAM modules in `Rc<RefCell<>>` so we can keep a reference to them at top level.
Going to be necessary for save-states.

I expected this to be a small drop in performance, but testing appears to show it's actually a slight gain.  I have no idea why.