### PR TITLE
Adjust audio buffering strategy

### DIFF
--- a/src/bin/nes.rs
+++ b/src/bin/nes.rs
@@ -107,7 +107,7 @@ fn main_loop(controller: Rc<RefCell<Controller>>, compositor: &mut Compositor, a
             frame_ns = frame_time.as_secs() * 1_000_000_000 + (frame_time.subsec_nanos() as u64);
         }
 
-        audio_queue.flush();
+        audio_queue.flush(target_cycles_this_frame);
         compositor.set_debug(controller.borrow().debug_mode());
         compositor.render();
         input.pump();

--- a/src/bin/nes.rs
+++ b/src/bin/nes.rs
@@ -206,7 +206,7 @@ fn main_loop(
         }
 
         let request_samples = SAMPLE_RATE / (RENDER_FPS as f32);
-        audio_output.borrow_mut().consume(target_frame_cycles, request_samples as usize, |data| {
+        audio_output.borrow_mut().consume(target_frame_cycles, request_samples as u64, |data| {
             audio_portal.consume(|portal| {
                 portal.extend_from_slice(data);
             });

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -30,9 +30,9 @@ use emulator::state::{NESState, SaveState};
 // CPU clock = 12 master clocks.
 // PPU clock = 4 master clocks.
 pub const NES_MASTER_CLOCK_HZ: u64 = 21_477_272;
-const NES_CPU_CLOCK_FACTOR: u32 = 12;
-const NES_APU_CLOCK_FACTOR: u32 = 24;
-const NES_PPU_CLOCK_FACTOR: u32 = 4;
+pub const NES_CPU_CLOCK_FACTOR: u32 = 12;
+pub const NES_APU_CLOCK_FACTOR: u32 = 24;
+pub const NES_PPU_CLOCK_FACTOR: u32 = 4;
 
 pub struct NES {
     clock: clock::Clock,

--- a/src/ui/audio.rs
+++ b/src/ui/audio.rs
@@ -35,11 +35,11 @@ impl AudioQueue {
         }
     }
 
-    pub fn flush(&mut self) {
+    pub fn flush(&mut self, master_cycles: u64) {
         let mut output = self.output.borrow_mut();
         let queue = &mut self.queue;
         let request_samples = SAMPLE_RATE / (RENDER_FPS as f32);
-        output.consume(request_samples as usize, |data| {
+        output.consume(master_cycles, request_samples as u64, |data| {
             queue.queue(&data);
         });
     }


### PR DESCRIPTION
Now we downsample audio based on the number of elapsed cycles.  This causes the audio to degrade (slightly) more gracefully when performance drops.  Instead of wildly changing pitch, it will stutter, which I think is slightly nicer.

Note:  we have to pass through these values into the emulator code instead of just assuming them in order to still get the pitch-bending quality when adjusting the emulation speed.